### PR TITLE
Update sat_282_sky_uk.xml

### DIFF
--- a/AutoBouquetsMaker/providers/sat_282_sky_uk.xml
+++ b/AutoBouquetsMaker/providers/sat_282_sky_uk.xml
@@ -352,7 +352,7 @@ except:
 	########################################################################
 
 	channels_to_add = {
-		"London Live": 117 #This is only added if you do not have an official local 117 service
+		"London Live": 173 #This will add London Live at 173 when it's free, which is currently everywhere except London. In London Sky puts London Live at 117 and BBC Three at 173.
 	}
 
 	channels_to_add_by_id = {


### PR DESCRIPTION
This will add London Live at 173 when it's free, which is currently everywhere except London. In London Sky puts London Live at 117 and BBC Three at 173.